### PR TITLE
Fix user agent not showing app info

### DIFF
--- a/MONK/Public/Extensions/URLSessionConfiguration+Default.swift
+++ b/MONK/Public/Extensions/URLSessionConfiguration+Default.swift
@@ -67,7 +67,7 @@ private var userAgent: String = {
     let deviceInfo = "(\(modelName()), \(displayScale()), \(osVersionAndBuild))"
     
     guard let info = bundle.infoDictionary,
-        let appName = info["CFBundleDisplayName"],
+        let appName = info["CFBundleDisplayName"] ?? info["CFBundleName"],
         let appVersion = info["CFBundleShortVersionString"],
         let appBuild = info[kCFBundleVersionKey as String] else {
         


### PR DESCRIPTION
If an app didn't have a display name, then the user agent would show the `Mobelux NetworkKit - <os/device info here>` user agent string, instead of the app name/version. Fixes #9 