### PR TITLE
Completion on Cancel

### DIFF
--- a/MONK/Internal/Classes/MutableDataTask.swift
+++ b/MONK/Internal/Classes/MutableDataTask.swift
@@ -115,6 +115,7 @@ final class MutableDataTask: DataTask, CompletableTask {
     func cancel() {
         dataTask.cancel()
         
+        completionHandlers.forEach { $0(.failure(error: nil)) }
         removeHandlers()
     }
     

--- a/MONK/Internal/Classes/MutableDownloadTask.swift
+++ b/MONK/Internal/Classes/MutableDownloadTask.swift
@@ -94,6 +94,7 @@ final class MutableDownloadTask: DownloadTask, CompletableTask {
     func cancel() {
         downloadTask.cancel()
         
+        completionHandlers.forEach { $0(.failure(error: nil)) }
         removeHandlers()
         
         let _ = try? FileManager.default.removeItem(at: downloadRequest.localURL)


### PR DESCRIPTION
When cancelling a task we need to be sure to call the completion handler so the consumer can clean up.